### PR TITLE
Update php7-compat.php

### DIFF
--- a/php7-compat.php
+++ b/php7-compat.php
@@ -60,14 +60,19 @@ if( !function_exists( 'mysql_close' ) )
 	}
 }
 
-if( !function_exists( 'mysql_connect' ) )
+if (!function_exists('mysql_connect'))
 {
-	function mysql_connect( $server = '', $user = '', $password = '', $new_link = false, $client_flags = 0 )
+	function mysql_connect($server = '', $user = '', $password = '', $new_link = false, $client_flags = 0)
 	{
-		if( !$server ) $server = ini_get( 'mysqli.default_host' );
-		if( !$user ) $user = ini_get( 'mysqli.default_user' );
-		if( !$password ) $password = ini_get( 'mysqli.default_pw' );
-		return mysqli_connect( $server, $user, $password );
+		global $_php7_compat_global_db_link;
+		
+		if (!$server) $server = ini_get('mysqli.default_host');
+		if (!$user) $user = ini_get('mysqli.default_user');
+		if (!$password) $password = ini_get('mysqli.default_pw');
+		
+		$link = mysqli_connect($server, $user, $password);
+		if (!$_php7_compat_global_db_link) $_php7_compat_global_db_link = $link;
+		return $link;
 	}
 }
 


### PR DESCRIPTION
added a fix for mysql_connect to work as expected in php5 (having a globally open link was usually used, not passing the link var)