### PR TITLE
Set $_php7_compat_global_db_link in mysql_connect to be consistent wi…

### DIFF
--- a/php7-compat.php
+++ b/php7-compat.php
@@ -64,10 +64,16 @@ if( !function_exists( 'mysql_connect' ) )
 {
 	function mysql_connect( $server = '', $user = '', $password = '', $new_link = false, $client_flags = 0 )
 	{
+		global $_php7_compat_global_db_link;
+		
 		if( !$server ) $server = ini_get( 'mysqli.default_host' );
 		if( !$user ) $user = ini_get( 'mysqli.default_user' );
 		if( !$password ) $password = ini_get( 'mysqli.default_pw' );
-		return mysqli_connect( $server, $user, $password );
+
+		$link = mysqli_connect( $server, $user, $password );
+		if( !$_php7_compat_global_db_link ) $_php7_compat_global_db_link = $link;
+		return $link;
+
 	}
 }
 


### PR DESCRIPTION
…th mysql_pconnect

mysql_pconnect() is properly setting the global db link, but mysql_connect() does not.